### PR TITLE
docs(frameworks): add HITRUST CSF v11.6.0 framework documentation

### DIFF
--- a/frameworks/2025-08-cybersecurity-framework-11-6-0-by-hitrust.md
+++ b/frameworks/2025-08-cybersecurity-framework-11-6-0-by-hitrust.md
@@ -1,0 +1,21 @@
+# 2025-08 Cybersecurity Framework v11.6.0 by HITRUST
+
+> Retrieved on 2025-08-31 by @KemingHe from [[hitrustalliance.net](https://hitrustalliance.net/advisories/haa-2025-003)]
+
+## Files
+
+- **PDF**: [[Original Document](https://drive.google.com/file/d/1qVBMXjU1uQiOKteIn1QKTZKwtGtfxtfp/view?usp=sharing)]
+- **Audio**: [[Audio Overview](https://drive.google.com/file/d/1m-JrLoLuctOom3103TwCZj-zDXC0awtD/view?usp=sharing)]
+- **Video**: [[Video Overview](https://drive.google.com/file/d/1kruvvjk8aalQPxOujT970SOnV5n3TpbM/view?usp=sharing)]
+
+## Significance
+
+The HITRUST CSF v11.6.0 delivers 14 comprehensive control categories covering 181 specific control objectives, introduces AI-specific security requirements, and integrates diverse regulatory frameworks including GDPR, HIPAA, PCI DSS, and NIST standards.
+
+As organizations navigate complex multi-jurisdictional compliance landscapes and emerging AI security threats, comprehensive frameworks that unify regulatory requirements become essential for risk management.
+
+This framework advances security professionals, compliance officers, and privacy managers by providing structured methodologies for implementing risk-based security programs and achieving regulatory harmonization.
+
+---
+
+> Cybersecurity Document Template v1.0.0 - KemingHe/cybersecurity-readings


### PR DESCRIPTION
CHANGES
- Add comprehensive HITRUST CSF v11.6.0 framework document with complete significance analysis
- Include AI-specific security requirements coverage
- Integrate Google Drive links for PDF, audio, and video resources

IMPACT
- Expands framework collection with Google Cybersecurity Certification recommended resource
- Provides security professionals access to 14 control categories and 181 control objectives
- Enables regulatory harmonization across GDPR, HIPAA, PCI DSS, and NIST standards

TECHNICAL NOTES
- Document follows established cybersecurity readings template v1.0.0
- Framework positioned alongside existing NIST documentation in frameworks directory